### PR TITLE
Security: Dependabot findings.

### DIFF
--- a/.github/workflows/build.from.main.branch.deploy.to.dev.yml
+++ b/.github/workflows/build.from.main.branch.deploy.to.dev.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Determine image tags
         if: env.TAG == ''

--- a/.github/workflows/build.from.release.branch.deploy.to.dev.yml
+++ b/.github/workflows/build.from.release.branch.deploy.to.dev.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: grad-release
 

--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Create tag
         uses: actions/github-script@v5
@@ -54,7 +54,7 @@ jobs:
           oc: 4
 
         # https://github.com/redhat-actions/oc-login#readme
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Tag in OpenShift
         run: |
           set -eux

--- a/.github/workflows/deploy.to.dev.jinil.yaml
+++ b/.github/workflows/deploy.to.dev.jinil.yaml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: develop/jinil
 

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get latest tag
         uses: actions-ecosystem/action-get-latest-tag@v1

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get latest tag
         uses: actions-ecosystem/action-get-latest-tag@v1

--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -17,12 +17,13 @@ jobs:
         working-directory: api
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 18
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'corretto'
           java-version: 18
       - uses: actions/cache@v1
         with:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -42,10 +42,10 @@
         <springdoc.version>2.0.2</springdoc.version>
         <ojdbc.version>21.6.0.0.1</ojdbc.version>
         <nats.version>2.11.0</nats.version>
-        <guava.version>30.1.1-jre</guava.version>
+        <guava.version>33.4.0-jre</guava.version>
         <shedlock.version>4.20.0</shedlock.version>
         <junit>4.12</junit>
-        <log4j.version>2.18.0</log4j.version>
+        <log4j.version>2.20.0</log4j.version>
         <resilience4j.version>1.7.1</resilience4j.version>
     </properties>
 
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>
-            <version>2.3.6</version>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>io.github.resilience4j</groupId>
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20220320</version>
+            <version>20250107</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/net.javacrumbs.shedlock/shedlock-spring -->
         <dependency>
@@ -252,7 +252,7 @@
         <plugin>
           <groupId>org.hibernate.orm.tooling</groupId>
           <artifactId>hibernate-enhance-maven-plugin</artifactId>
-          <version>6.1.1.Final</version>
+          <version>6.6.4.Final</version>
         </plugin>
         <plugin>
           <groupId>org.springframework.boot</groupId>
@@ -336,7 +336,7 @@
           <plugin>
             <groupId>org.hibernate.orm.tooling</groupId>
             <artifactId>hibernate-enhance-maven-plugin</artifactId>
-            <version>6.1.1.Final</version>
+            <version>6.6.4.Final</version>
             <executions>
               <execution>
                 <configuration>


### PR DESCRIPTION
Change Details:

- Bump org.json:json from 20220320 to 20250107 
- Bump org.hibernate.orm.tooling:hibernate-enhance-maven-plugin from 6.1.1.Final to 6.6.4.Final 
- Bump com.google.guava:guava from 30.1.1-jre to 33.4.0-jre 
- Bump org.modelmapper:modelmapper from 2.3.6 to 3.2.2 
- Bump actions/setup-java from 1 to 4 
- Bump actions/checkout from 2 to 4
- Bump log4j.version from 2.18.0 to 2.24.2 [Used 2.20.0]